### PR TITLE
fix: remove dot_drawer.lua and shu_game.lua

### DIFF
--- a/v2/data/mod.xml
+++ b/v2/data/mod.xml
@@ -2,7 +2,7 @@
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod version="2">
 	<core>2022-04-04T18:12:00+09:00</core>
-	<packages>2022-07-04T05:48:00+09:00</packages>
+	<packages>2022-07-05T02:48:00+09:00</packages>
 	<convert>2021-12-11T16:03:00+09:00</convert>
-	<scripts>2022-06-25T18:05:00+09:00</scripts>
+	<scripts>2022-07-05T02:48:00+09:00</scripts>
 </mod>

--- a/v2/data/packages.xml
+++ b/v2/data/packages.xml
@@ -3497,64 +3497,6 @@
 	<!-- しゅう ID:shummg -->
 
 	<package>
-		<id>shummg/dotdrawer</id>
-		<name>dotdrawer</name>
-		<overview>ドット絵を描画するためのライブラリ</overview>
-		<description
-		>dotdrawerは、ドット絵を描画するだけのシンプルなライブラリです。</description>
-		<developer>しゅう</developer>
-		<pageURL>https://shummg.work/archives/1231</pageURL>
-		<downloadURL
-		>https://github.com/shumm7/AviUtl-dotdrawer.lua/releases/latest</downloadURL>
-		<latestVersion>1.1</latestVersion>
-		<files>
-			<file>script/shummg/dotdrawer.lua</file>
-		</files>
-		<releases>
-			<release version="1.1">
-				<archiveIntegrity
-				>sha384-pg/9VD7ZZLOcenlC/NIprGYlgMrxuzxcB7h75IEbYcuEepY5ZRMc/3yfxynoqk0X</archiveIntegrity>
-				<integrities>
-					<integrity
-						target="script/shummg/dotdrawer.lua"
-					>sha384-kfm/wnRgGySW1tr7F0kX7vD91VtnR+58s1Hyabvge6PoZZswVnFjoiqVAz55z9kL</integrity>
-				</integrities>
-			</release>
-		</releases>
-	</package>
-
-	<package>
-		<id>shummg/shuGame</id>
-		<name>shu_game</name>
-		<overview>「オセロ」や「マインスイーパ」の動作に必要</overview>
-		<description
-		>「オセロ」や「マインスイーパ」などに要求されるスクリプトです。</description>
-		<developer>しゅう</developer>
-		<dependencies>
-			<dependency>rikky/rikkyModuleMemory|rikky/rikkyModule2</dependency>
-		</dependencies>
-		<pageURL
-		>https://shummg.work/downloads/#%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA</pageURL>
-		<downloadURL
-		>https://github.com/shumm7/AviUtl-shu_game.lua/releases/latest</downloadURL>
-		<latestVersion>1.1</latestVersion>
-		<files>
-			<file>script/shummg/shu_game.lua</file>
-		</files>
-		<releases>
-			<release version="1.1">
-				<archiveIntegrity
-				>sha384-soXtIGntr1QO/jvsrUcIvPvv6YjrfI45qS1tRF7nlv0B5t8HcyMPS1/jK8xBa2OD</archiveIntegrity>
-				<integrities>
-					<integrity
-						target="script/shummg/shu_game.lua"
-					>sha384-qFXsL73G/vC9lo4sUqqtkqqIG/TP8ZGcKrbCylto/YJeWw1BibUPkS4tnNQZ/6vC</integrity>
-				</integrities>
-			</release>
-		</releases>
-	</package>
-
-	<package>
 		<id>shummg/textmodule</id>
 		<name>textmodule</name>
 		<overview>AviUtl用の様々な関数を提供する汎用モジュール</overview>

--- a/v2/data/scripts.json
+++ b/v2/data/scripts.json
@@ -53,7 +53,7 @@
     {
       "url": "https://shummg.work/downloads/",
       "developer": "しゅう",
-      "description": "スクリプトの例: @Square-Advanced, @DisplaySizeオセロ, @球座標回転, @任意関数図形, @媒介変数図形, @年月日カウンター, @等間隔に配置, @カメラ座標, @座標制御, @RadialPosition, @SphericalRadialPosition, @十字, @角丸十字, @放射線, PercentageClipping, @QR, @角丸吹き出し, @カラオケテキスト, @心電図, @カラーバー, @Winアイコン, @TA交互移動, オセロ, マインスイーパ, 明度着色, 一括画像編集, @ZoomLine, @ScreenCapture, @テキスト遷移, @モザイクとノイズ, @MathTrack, @BufferMask, トリミングS, WaveRing"
+      "description": "スクリプトの例: @Square-Advanced, @DisplaySize, オセロ, @球座標回転, @任意関数図形, @媒介変数図形, @年月日カウンター, @等間隔に配置, @カメラ座標, @座標制御, @RadialPosition, @SphericalRadialPosition, @十字, @角丸十字, @放射線, PercentageClipping, @QR, @角丸吹き出し, @カラオケテキスト, @心電図, @カラーバー, @TA交互移動, オセロ, マインスイーパ, 明度着色, 一括画像編集, @ZoomLine, @ScreenCapture, @テキスト遷移, @モザイクとノイズ, @MathTrack, @BufferMask, トリミングS, WaveRing"
     },
     {
       "url": "https://www.nicovideo.jp/user/26576669/mylist/37628454",
@@ -189,28 +189,6 @@
         "rikky/rikkyModuleMemory|rikky/rikkyModule2",
         "shummg/textmodule",
         "ePi/LuaJIT"
-      ]
-    },
-    {
-      "match": ["*AviUtl-Othello*", "*AviUtl-MineSweeper*"],
-      "folder": "shummg",
-      "developer": "しゅう",
-      "dependencies": [
-        "rikky/rikkyModuleMemory|rikky/rikkyModule2",
-        "shummg/textmodule",
-        "ePi/LuaJIT",
-        "shummg/shuGame"
-      ]
-    },
-    {
-      "match": ["*@Winアイコン*"],
-      "folder": "shummg",
-      "developer": "しゅう",
-      "dependencies": [
-        "rikky/rikkyModuleMemory|rikky/rikkyModule2",
-        "shummg/textmodule",
-        "ePi/LuaJIT",
-        "shummg/dotdrawer"
       ]
     },
     {

--- a/v3/list.json
+++ b/v3/list.json
@@ -10,7 +10,7 @@
   "packages": [
     {
       "path": "packages.json",
-      "modified": "2022-07-04T05:48:00+09:00"
+      "modified": "2022-07-05T02:47:00+09:00"
     },
     {
       "path": "package-sets.json",
@@ -20,7 +20,7 @@
   "scripts": [
     {
       "path": "scripts.json",
-      "modified": "2022-06-25T18:05:00+09:00"
+      "modified": "2022-07-05T02:47:00+09:00"
     }
   ]
 }

--- a/v3/packages.json
+++ b/v3/packages.json
@@ -3798,61 +3798,6 @@
       ]
     },
     {
-      "id": "shummg/dotdrawer",
-      "name": "dotdrawer",
-      "overview": "ドット絵を描画するためのライブラリ",
-      "description": "dotdrawerは、ドット絵を描画するだけのシンプルなライブラリです。",
-      "developer": "しゅう",
-      "pageURL": "https://shummg.work/archives/1231",
-      "downloadURLs": [
-        "https://github.com/shumm7/AviUtl-dotdrawer.lua/releases/latest"
-      ],
-      "latestVersion": "1.1",
-      "files": [{ "filename": "script/shummg/dotdrawer.lua" }],
-      "releases": [
-        {
-          "version": "1.1",
-          "integrity": {
-            "archive": "sha384-pg/9VD7ZZLOcenlC/NIprGYlgMrxuzxcB7h75IEbYcuEepY5ZRMc/3yfxynoqk0X",
-            "file": [
-              {
-                "target": "script/shummg/dotdrawer.lua",
-                "hash": "sha384-kfm/wnRgGySW1tr7F0kX7vD91VtnR+58s1Hyabvge6PoZZswVnFjoiqVAz55z9kL"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "id": "shummg/shuGame",
-      "name": "shu_game",
-      "overview": "「オセロ」や「マインスイーパ」の動作に必要",
-      "description": "「オセロ」や「マインスイーパ」などに要求されるスクリプトです。",
-      "developer": "しゅう",
-      "dependencies": ["rikky/rikkyModuleMemory|rikky/rikkyModule2"],
-      "pageURL": "https://shummg.work/downloads/#%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA",
-      "downloadURLs": [
-        "https://github.com/shumm7/AviUtl-shu_game.lua/releases/latest"
-      ],
-      "latestVersion": "1.1",
-      "files": [{ "filename": "script/shummg/shu_game.lua" }],
-      "releases": [
-        {
-          "version": "1.1",
-          "integrity": {
-            "archive": "sha384-soXtIGntr1QO/jvsrUcIvPvv6YjrfI45qS1tRF7nlv0B5t8HcyMPS1/jK8xBa2OD",
-            "file": [
-              {
-                "target": "script/shummg/shu_game.lua",
-                "hash": "sha384-qFXsL73G/vC9lo4sUqqtkqqIG/TP8ZGcKrbCylto/YJeWw1BibUPkS4tnNQZ/6vC"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
       "id": "shummg/textmodule",
       "name": "textmodule",
       "overview": "AviUtl用の様々な関数を提供する汎用モジュール",

--- a/v3/scripts.json
+++ b/v3/scripts.json
@@ -53,7 +53,7 @@
     {
       "url": "https://shummg.work/downloads/",
       "developer": "しゅう",
-      "description": "スクリプトの例: @Square-Advanced, @DisplaySizeオセロ, @球座標回転, @任意関数図形, @媒介変数図形, @年月日カウンター, @等間隔に配置, @カメラ座標, @座標制御, @RadialPosition, @SphericalRadialPosition, @十字, @角丸十字, @放射線, PercentageClipping, @QR, @角丸吹き出し, @カラオケテキスト, @心電図, @カラーバー, @Winアイコン, @TA交互移動, オセロ, マインスイーパ, 明度着色, 一括画像編集, @ZoomLine, @ScreenCapture, @テキスト遷移, @モザイクとノイズ, @MathTrack, @BufferMask, トリミングS, WaveRing"
+      "description": "スクリプトの例: @Square-Advanced, @DisplaySize, オセロ, @球座標回転, @任意関数図形, @媒介変数図形, @年月日カウンター, @等間隔に配置, @カメラ座標, @座標制御, @RadialPosition, @SphericalRadialPosition, @十字, @角丸十字, @放射線, PercentageClipping, @QR, @角丸吹き出し, @カラオケテキスト, @心電図, @カラーバー, @TA交互移動, オセロ, マインスイーパ, 明度着色, 一括画像編集, @ZoomLine, @ScreenCapture, @テキスト遷移, @モザイクとノイズ, @MathTrack, @BufferMask, トリミングS, WaveRing"
     },
     {
       "url": "https://www.nicovideo.jp/user/26576669/mylist/37628454",
@@ -189,28 +189,6 @@
         "rikky/rikkyModuleMemory|rikky/rikkyModule2",
         "shummg/textmodule",
         "ePi/LuaJIT"
-      ]
-    },
-    {
-      "match": ["*AviUtl-Othello*", "*AviUtl-MineSweeper*"],
-      "folder": "shummg",
-      "developer": "しゅう",
-      "dependencies": [
-        "rikky/rikkyModuleMemory|rikky/rikkyModule2",
-        "shummg/textmodule",
-        "ePi/LuaJIT",
-        "shummg/shuGame"
-      ]
-    },
-    {
-      "match": ["*@Winアイコン*"],
-      "folder": "shummg",
-      "developer": "しゅう",
-      "dependencies": [
-        "rikky/rikkyModuleMemory|rikky/rikkyModule2",
-        "shummg/textmodule",
-        "ePi/LuaJIT",
-        "shummg/dotdrawer"
       ]
     },
     {


### PR DESCRIPTION
## Description
Remove some own scripts (shu_game.lua and dot_drawer.lua) from apm. The reason is as follows.
- dot_drawer.lua and @Winアイコン have been discontinued
- オセロ and マインスイーパ have been able to download shu_game.lua automatically

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Updated the modification date in `mod.xml`.
