### PR TITLE
fix: update the archivePath of suzune/WideDialog

### DIFF
--- a/v3/list.json
+++ b/v3/list.json
@@ -10,7 +10,7 @@
   "packages": [
     {
       "path": "packages.json",
-      "modified": "2022-08-20T05:49:00+09:00"
+      "modified": "2022-08-21T21:54:00+09:00"
     },
     {
       "path": "package-sets.json",

--- a/v3/packages.json
+++ b/v3/packages.json
@@ -5129,7 +5129,7 @@
       "files": [
         {
           "filename": "plugins/WideDialog.auf",
-          "archivePath": "WideDialog_aviutl_plugin-1.02/"
+          "archivePath": "WideDialog_aviutl_plugin-1.04/"
         }
       ],
       "releases": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- update archivePath of suzune/WideDialog

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- team-apm/apm#765

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
