### PR TITLE
fix: specify shift_jis when linux

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -18,11 +18,12 @@ jobs:
         with:
           node-version: '16'
           cache: yarn
+      - run: sudo apt update; sudo apt install convmv
       - run: yarn install --frozen-lockfile
       - run: mr_ojii_file=`curl -s 'https://api.github.com/repos/Mr-Ojii/L-SMASH-Works-Auto-Builds/releases/latest' | jq -r '.assets[] | select(.name|test("Mr-Ojii_Mr-Ojii")).name'` && echo "mr_ojii_file=$mr_ojii_file" >> $GITHUB_ENV
       - run: sed -i "s/L-SMASH-Works_rev[0-9]*_Mr-Ojii_Mr-Ojii_AviUtl\.zip/${{ env.mr_ojii_file }}/g" v3/packages.json
       - run: sudo chmod -R u+x /home/runner/work/apm-data/apm-data/node_modules/7zip-bin
-      - run: yarn run check-update
+      - run: LANG=C yarn run check-update
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/util/lib/unzip.js
+++ b/util/lib/unzip.js
@@ -1,6 +1,15 @@
 import { path7za } from '7zip-bin';
 import Seven from 'node-7z';
+import { execFileSync } from 'child_process';
 const { extractFull } = Seven;
+
+const isLinux = process.platform === 'linux';
+// NOTE
+// On Linux, 7zip assumes utf8 by default. Use the C locale instead.
+// $LANG=C node THIS_FUNCTION.js
+// or $LANG=C yarn run THIS_FUNCTION.js
+//
+// To run this file on Linux, you must install `convmv`.
 
 export default async function unzip(zipPath, outputPath) {
   const zipStream = extractFull(zipPath, outputPath, {
@@ -10,6 +19,11 @@ export default async function unzip(zipPath, outputPath) {
 
   return new Promise((resolve) => {
     zipStream.once('end', () => {
+      if (isLinux)
+        execFileSync('convmv', [
+          ...'-f shift_jis -t utf8 -r --notest'.split(' '),
+          outputPath,
+        ]); // Convert file names to utf8 on Linux.
       resolve();
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a problem that integrity with Japanese file name is not generated when a package is automatically updated.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have done a test run of Github Actions in my repository.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~Updated the modification date in `mod.xml`.~~
