### PR TITLE
fix2: remove dot_drawer.lua and shu_game.lua

### DIFF
--- a/v3/list.json
+++ b/v3/list.json
@@ -24,7 +24,7 @@
   "scripts": [
     {
       "path": "scripts.json",
-      "modified": "2022-07-01T22:16:00+09:00"
+      "modified": "2023-01-15T17:09:00+09:00"
     }
   ]
 }

--- a/v3/packages.json
+++ b/v3/packages.json
@@ -9136,6 +9136,7 @@
         "https://github.com/shumm7/AviUtl-dotdrawer.lua/releases/latest"
       ],
       "latestVersion": "1.1",
+      "isHidden": true,
       "files": [{ "filename": "script/shummg/dotdrawer.lua" }],
       "releases": [
         {
@@ -9176,6 +9177,7 @@
         "https://github.com/shumm7/AviUtl-shu_game.lua/releases/latest"
       ],
       "latestVersion": "1.1",
+      "isHidden": true,
       "files": [{ "filename": "script/shummg/shu_game.lua" }],
       "releases": [
         {

--- a/v3/scripts.json
+++ b/v3/scripts.json
@@ -53,7 +53,7 @@
     {
       "url": "https://shummg.work/downloads/",
       "developer": "しゅう",
-      "description": "スクリプトの例: @Square-Advanced, @DisplaySizeオセロ, @球座標回転, @任意関数図形, @媒介変数図形, @年月日カウンター, @等間隔に配置, @カメラ座標, @座標制御, @RadialPosition, @SphericalRadialPosition, @十字, @角丸十字, @放射線, PercentageClipping, @QR, @角丸吹き出し, @カラオケテキスト, @心電図, @カラーバー, @Winアイコン, @TA交互移動, オセロ, マインスイーパ, 明度着色, 一括画像編集, @ZoomLine, @ScreenCapture, @テキスト遷移, @モザイクとノイズ, @MathTrack, @BufferMask, トリミングS, WaveRing"
+      "description": "スクリプトの例: @Square-Advanced, @DisplaySize, オセロ, @球座標回転, @任意関数図形, @媒介変数図形, @年月日カウンター, @等間隔に配置, @カメラ座標, @座標制御, @RadialPosition, @SphericalRadialPosition, @十字, @角丸十字, @放射線, PercentageClipping, @QR, @角丸吹き出し, @カラオケテキスト, @心電図, @カラーバー, @TA交互移動, オセロ, マインスイーパ, 明度着色, 一括画像編集, @ZoomLine, @ScreenCapture, @テキスト遷移, @モザイクとノイズ, @MathTrack, @BufferMask, トリミングS, WaveRing"
     },
     {
       "url": "https://www.nicovideo.jp/user/26576669/mylist/37628454",
@@ -193,17 +193,6 @@
         "rikky/rikkyModuleMemory|rikky/rikkyModule2",
         "shummg/textmodule",
         "ePi/LuaJIT"
-      ]
-    },
-    {
-      "match": ["*AviUtl-Othello*", "*AviUtl-MineSweeper*"],
-      "folder": "shummg",
-      "developer": "しゅう",
-      "dependencies": [
-        "rikky/rikkyModuleMemory|rikky/rikkyModule2",
-        "shummg/textmodule",
-        "ePi/LuaJIT",
-        "shummg/shuGame"
       ]
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make #274, a PR created by @shumm7 for data v2, compatible with data v3.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- closes #274

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Othello and MineSweeper work properly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`. **The change date of packages is not updated to avoid conflicts.**
