### PR TITLE
feat: directURL with build number

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -20,8 +20,8 @@ jobs:
           cache: yarn
       - run: sudo apt update; sudo apt install convmv
       - run: yarn install --frozen-lockfile
-      - run: mr_ojii_file=`curl -s 'https://api.github.com/repos/Mr-Ojii/L-SMASH-Works-Auto-Builds/releases/latest' | jq -r '.assets[] | select(.name|test("Mr-Ojii_Mr-Ojii")).name'` && echo "mr_ojii_file=$mr_ojii_file" >> $GITHUB_ENV
-      - run: sed -i "s/L-SMASH-Works_rev[0-9]*_Mr-Ojii_Mr-Ojii_AviUtl\.zip/${{ env.mr_ojii_file }}/g" v3/packages.json
+      - run: mr_ojii_file=`curl -s 'https://api.github.com/repos/Mr-Ojii/L-SMASH-Works-Auto-Builds/releases/latest' | jq -r '.assets[] | select(.name|test("Mr-Ojii_Mr-Ojii")).browser_download_url'` && echo "mr_ojii_file=$mr_ojii_file" >> $GITHUB_ENV
+      - run: sed -i "s/https:\/\/github\.com\/Mr-Ojii\/L-SMASH-Works-Auto-Builds\/releases\/download.*_Mr-Ojii_Mr-Ojii_AviUtl\.zip/${{ env.mr_ojii_file }}/g" v3/packages.json
       - run: sudo chmod -R u+x /home/runner/work/apm-data/apm-data/node_modules/7zip-bin
       - run: LANG=C yarn run check-update
       - name: Create Pull Request

--- a/v3/list.json
+++ b/v3/list.json
@@ -10,15 +10,15 @@
   "packages": [
     {
       "path": "packages.json",
-      "modified": "2023-01-15T16:42:00+09:00"
+      "modified": "2023-01-16T23:10:00+09:00"
     },
     {
       "path": "package-sets.json",
-      "modified": "2022-06-25T17:15:00+09:00"
+      "modified": "2023-01-15T16:42:00+09:00"
     },
     {
       "path": "packages/tim.json",
-      "modified": "2022-06-25T17:15:00+09:00"
+      "modified": "2023-01-15T16:42:00+09:00"
     }
   ],
   "scripts": [

--- a/v3/packages.json
+++ b/v3/packages.json
@@ -4352,7 +4352,7 @@
       "downloadURLs": [
         "https://github.com/Mr-Ojii/L-SMASH-Works-Auto-Builds/releases/latest"
       ],
-      "directURL": "https://github.com/Mr-Ojii/L-SMASH-Works-Auto-Builds/releases/latest/download/L-SMASH-Works_rev1102_Mr-Ojii_Mr-Ojii_AviUtl.zip",
+      "directURL": "https://github.com/Mr-Ojii/L-SMASH-Works-Auto-Builds/releases/download/build-2023-01-13-13-40-23/L-SMASH-Works_rev1101_Mr-Ojii_Mr-Ojii_AviUtl.zip",
       "latestVersion": "最新",
       "isContinuous": true,
       "files": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix problem with apm's "recommended install" feature breaking every time MrOjii/LSMASHWorks is updated.

I am intentionally specifying the old `rev1101` zip file to test the proper execution of Action.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The commands has been tested on linux, not on Github Action.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
