### PR TITLE
feat: run the update in Windows

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check:
     name: Check Update
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     env:
       TZ: 'Asia/Tokyo'
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -16,14 +16,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: yarn
-      - run: sudo apt update; sudo apt install convmv
       - run: yarn install --frozen-lockfile
-      - run: mr_ojii_file=`curl -s 'https://api.github.com/repos/Mr-Ojii/L-SMASH-Works-Auto-Builds/releases/latest' | jq -r '.assets[] | select(.name|test("Mr-Ojii_Mr-Ojii")).browser_download_url'` && echo "mr_ojii_file=${mr_ojii_file//'/'/'\/'}" >> $GITHUB_ENV
-      - run: sed -i "s/https:\/\/github\.com\/Mr-Ojii\/L-SMASH-Works-Auto-Builds\/releases\/download.*_Mr-Ojii_Mr-Ojii_AviUtl\.zip/${{ env.mr_ojii_file }}/g" v3/packages.json
-      - run: sudo chmod -R u+x /home/runner/work/apm-data/apm-data/node_modules/7zip-bin
-      - run: LANG=C yarn run check-update
+      - run: yarn run check-update
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/util/check-update.js
+++ b/util/check-update.js
@@ -35,8 +35,7 @@ async function checkPackageUpdate(packageItem) {
   if (
     exclude.includes(id) ||
     downloadURL.hostname !== 'github.com' ||
-    dirs[2] !== 'releases' ||
-    currentVersion === '最新'
+    dirs[2] !== 'releases'
   )
     return result;
 
@@ -58,6 +57,24 @@ async function checkPackageUpdate(packageItem) {
       } else {
         throw new Error('A version-like string is not found.');
       }
+    }
+
+    if (id === 'MrOjii/LSMASHWorks' && packageItem.directURL) {
+      const newDownloadUrl = res.data.assets.find((asset) =>
+        asset.name.includes('Mr-Ojii_Mr-Ojii')
+      ).browser_download_url;
+      if (newDownloadUrl && packageItem.directURL !== newDownloadUrl) {
+        packageItem.directURL = newDownloadUrl;
+        result.updateAvailable = true;
+        result.message.push(
+          whiteBright(id) + ' ' + cyanBright('The directURL has been updated.')
+        );
+        return result;
+      } else return result;
+    }
+
+    if (currentVersion === '最新') {
+      return result;
     }
 
     if (latestTag === currentVersion) {

--- a/util/lib/unzip.js
+++ b/util/lib/unzip.js
@@ -1,15 +1,6 @@
 import { path7za } from '7zip-bin';
 import Seven from 'node-7z';
-import { execFileSync } from 'child_process';
 const { extractFull } = Seven;
-
-const isLinux = process.platform === 'linux';
-// NOTE
-// On Linux, 7zip assumes utf8 by default. Use the C locale instead.
-// $LANG=C node THIS_FUNCTION.js
-// or $LANG=C yarn run THIS_FUNCTION.js
-//
-// To run this file on Linux, you must install `convmv`.
 
 export default async function unzip(zipPath, outputPath) {
   const zipStream = extractFull(zipPath, outputPath, {
@@ -19,11 +10,6 @@ export default async function unzip(zipPath, outputPath) {
 
   return new Promise((resolve) => {
     zipStream.once('end', () => {
-      if (isLinux)
-        execFileSync('convmv', [
-          ...'-f shift_jis -t utf8 -r --notest'.split(' '),
-          outputPath,
-        ]); // Convert file names to utf8 on Linux.
       resolve();
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, automatic updating of apm-data has stopped.

This PR allows workflow to run in a Windows environment similar to that of apm, preventing character code-related bugs that can cause stops.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have confirmed that `check-update` works correctly in my repository.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Updated the modification date in `mod.xml`.
