### PR TITLE
fix: prevent overwriting of the config file

### DIFF
--- a/v3/packages.json
+++ b/v3/packages.json
@@ -3163,7 +3163,7 @@
       "latestVersion": "4.3.1",
       "files": [
         { "filename": "plugins/SplitWindow.aul" },
-        { "filename": "plugins/SplitWindow.xml" },
+        { "filename": "plugins/SplitWindow.xml", "isUninstallOnly": true },
         { "filename": "plugins/SplitWindow", "isDirectory": true }
       ],
       "releases": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug that caused the configuration file, `SplitWindow.xml`, to be overwritten on update.

`SplitWindow.xml` is generated automatically and does not need to be copied during installation. apm only need to delete during uninstallation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/team-apm/apm/issues/1138

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Update of SplitWindow does not wipe the settings.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~Updated the modification date in `mod.xml`.~~ to avoid conflict
