### PR TITLE
feat: use bootstrap standard dark theme

### DIFF
--- a/docs/install-script.html
+++ b/docs/install-script.html
@@ -7,14 +7,14 @@
 
     <!-- Bootstrap CSS -->
     <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap-dark-5@1.1.3/dist/css/bootstrap-dark.min.css"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="main.css" />
 
     <title>AviUtl Package Manager</title>
   </head>
-  <body class="bg-light">
+  <body>
     <div class="container-fluid py-2">
       <h2>スクリプトのインストール</h2>
       <div class="my-2">
@@ -51,8 +51,8 @@
     </div>
 
     <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
       crossorigin="anonymous"
     ></script>
   </body>

--- a/docs/main.css
+++ b/docs/main.css
@@ -5,132 +5,17 @@
     'Hiragino Kaku Gothic ProN', 'Arial', 'Meiryo', sans-serif;
   --font-family-serif: 'Times New Roman', 'YuMincho', 'Hiragino Mincho ProN',
     'Yu Mincho', 'MS PMincho', serif;
+  --bs-border-radius: 0.2rem;
 }
 body {
   font-family: 'Helvetica Neue', 'Helvetica', 'Hiragino Sans',
     'Hiragino Kaku Gothic ProN', 'Arial', 'Meiryo', sans-serif;
 }
-.bg-light-on-surface {
-  background-color: var(--bs-light) !important;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bs-gray-850: #2e2e2e;
-    --bs-gray-950: #1a1a1a;
-    --bs-light-blue: #58a6ff;
-  }
-
-  /* dark mode background */
-  .bg-white {
-    background-color: var(--bs-gray-950) !important;
-  }
-  .bg-light {
-    background-color: var(--bs-gray-950) !important;
-  }
-  .card {
-    background-color: var(--bs-gray-900);
-  }
-  .bg-light-on-surface {
-    background-color: var(--bs-gray-850) !important;
-  }
-  .dropdown-menu {
-    background-color: var(--bs-gray-850);
-  }
-  .table-secondary {
-    --bs-table-bg: var(--bs-gray-850);
-  }
-
-  /* improve text visibility */
-  .text-primary {
-    color: var(--bs-light-blue) !important;
-  }
-  a {
-    color: var(--bs-light-blue);
-  }
-  .nav-tabs .nav-link {
-    color: var(--bs-body-color);
-  }
-  .nav-tabs .nav-link.active {
-    color: var(--bs-body-color);
-  }
-  .form-control {
-    color: var(--bs-gray-100);
-  }
-  .form-control:focus {
-    color: var(--bs-gray-100);
-  }
-  .form-control::placeholder {
-    color: var(--bs-gray-300);
-  }
-  .form-control::placeholder:focus {
-    color: var(--bs-gray-300);
-  }
-
-  /* use fill instead of outline */
-  .btn-outline-primary {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-primary:disabled {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-primary-rgb), 0.65);
-    border-color: rgba(var(--bs-primary-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-secondary {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-secondary:disabled {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-secondary-rgb), 0.65);
-    border-color: rgba(var(--bs-secondary-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-success {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-success:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-success-rgb), 0.65);
-    border-color: rgba(var(--bs-success-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-danger {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-danger:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-danger-rgb), 0.65);
-    border-color: rgba(var(--bs-danger-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-warning {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-warning:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-warning-rgb), 0.65);
-    border-color: rgba(var(--bs-warning-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-info {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-info:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-info-rgb), 0.65);
-    border-color: rgba(var(--bs-info-rgb), 0.65);
-    opacity: 1;
-  }
+.btn-primary {
+  --bs-btn-disabled-bg: #0b5ed7;
+  --bs-btn-disabled-border-color: #0a58ca;
+  --bs-btn-bg: #0b5ed7;
+  --bs-btn-border-color: #0a58ca;
+  --bs-btn-hover-bg: #0a58ca;
+  --bs-btn-hover-border-color: #0a53be;
 }

--- a/docs/package-sets-description.html
+++ b/docs/package-sets-description.html
@@ -7,14 +7,14 @@
 
     <!-- Bootstrap CSS -->
     <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap-dark-5@1.1.3/dist/css/bootstrap-dark.min.css"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="main.css" />
 
     <title>パッケージセットのインストール</title>
   </head>
-  <body class="bg-light">
+  <body>
     <div class="container-fluid py-2">
       <div class="my-2">
         <p class="">
@@ -27,8 +27,8 @@
     </div>
 
     <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
       crossorigin="anonymous"
     ></script>
   </body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace bootstrap-dark-5 with the standard dark theme added from Bootstrap 5.3.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Check the visibility of light and dark themes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~Updated the modification date in `mod.xml`.~
