### PR TITLE
fix: 切り取りプラグインの依存パッケージを修正

### DIFF
--- a/v3/packages.json
+++ b/v3/packages.json
@@ -5871,7 +5871,7 @@
       "overview": "拡張編集の切り取りを改善",
       "description": "拡張編集での特殊な切り取りをユーザーが期待する動作に変更します。リップル切り取りとグループ分割も実装しています。【動作にはVisual C++ 再頒布可能パッケージ 2015-2022 x86(32bit)のインストールが必要です https://aka.ms/vs/17/release/vc_redist.x86.exe 】",
       "developer": "謎の生物",
-      "dependencies": ["exedit0.92", "ePi/patch"],
+      "dependencies": ["exedit0.92", "ePi/patch|nazono/patch"],
       "pageURL": "https://www.nicovideo.jp/watch/sm41787566",
       "downloadURLs": [
         "https://github.com/nazonoSAUNA/tl_Item_cut/releases/latest"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `nazono/tlItemcut`の依存パッケージに、`nazono/patch`を追加

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The latest version can be installed and used.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Updated the modification date in `mod.xml`.

## Other
`releases`に同じ内容の`5.0`と`v5.0`が存在するのは意図的でしょうか？
![image](https://github.com/team-apm/apm-data/assets/50325323/63748579-b214-465e-95ff-4b73649f5095)
