### PR TITLE
fix: change lsmashworks location

### DIFF
--- a/v3/list.json
+++ b/v3/list.json
@@ -10,7 +10,7 @@
   "packages": [
     {
       "path": "packages.json",
-      "modified": "2024-11-09T05:49:00+09:00"
+      "modified": "2025-02-02T13:41:00+09:00"
     },
     {
       "path": "package-sets.json",

--- a/v3/packages.json
+++ b/v3/packages.json
@@ -46,11 +46,15 @@
       "downloadURLs": [
         "https://github.com/amate/InputPipePlugin/releases/latest"
       ],
-      "latestVersion": "v2.0",
+      "latestVersion": "v2.0_1",
       "nicommons": "sm35585310",
       "files": [
         {
           "filename": "plugins/InputPipeMain.exe",
+          "archivePath": "InputPipePlugin/"
+        },
+        {
+          "filename": "plugins/InputPipeMain64.exe",
           "archivePath": "InputPipePlugin/"
         },
         {
@@ -5351,19 +5355,39 @@
       "isContinuous": true,
       "files": [
         {
-          "filename": "lwcolor.auc"
+          "filename": "plugins/lwcolor.auc"
         },
         {
-          "filename": "lwdumper.auf"
+          "filename": "plugins/lwdumper.auf"
         },
         {
-          "filename": "lwinput.aui"
+          "filename": "plugins/lwinput.aui"
         },
         {
-          "filename": "lwinput64.aui"
+          "filename": "plugins/lwinput64.aui"
         },
         {
-          "filename": "lwmuxer.auf"
+          "filename": "plugins/lwmuxer.auf"
+        },
+        {
+          "filename": "lwcolor.auc",
+          "isObsolete": true
+        },
+        {
+          "filename": "lwdumper.auf",
+          "isObsolete": true
+        },
+        {
+          "filename": "lwinput.aui",
+          "isObsolete": true
+        },
+        {
+          "filename": "lwinput64.aui",
+          "isObsolete": true
+        },
+        {
+          "filename": "lwmuxer.auf",
+          "isObsolete": true
         }
       ],
       "releases": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Correct L-SMASH Works location. Also remove unnecessary integrity. 
- https://github.com/team-apm/apm/issues/1983

When `lwinput64.aui` is present, AviUtl freezes when opening the InputPipePlugin configuration screen without `InputPipeMain64.exe`. Therefore, add the `.exe` in this PR and increment the version so that the user is notified.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fix https://github.com/team-apm/apm/issues/1983

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After installation, the configuration screens for both plugins can be opened without problems.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
