### PR TITLE
ci: ワークフローを apm と同じ水準に揃える

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,10 @@ name: 'CodeQL'
 on:
   push:
     branches: [source]
+  # Do not restrict the base to source: pull requests targeting an intermediate
+  # branch (a stacked pull request) must be checked too. The branches filter
+  # matches the base, not the head, so restricting it leaves them unverified.
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [source]
   schedule:
     - cron: '43 19 * * 5'
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,13 @@ on:
     - cron: '43 19 * * 5'
   workflow_dispatch:
 
+# Cancel superseded runs for the same pull request. Pushes are not cancelled:
+# every commit on the default branch needs to keep its own Actions status, and
+# a burst of merges would otherwise discard the earlier ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel superseded runs for the same pull request. Pushes are not cancelled:
+# every commit on the default branch needs to keep its own Actions status, and
+# a burst of merges would otherwise discard the earlier ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,10 @@ name: Lint
 on:
   push:
     branches: [source]
+  # Do not restrict the base to source: pull requests targeting an intermediate
+  # branch (a stacked pull request) must be checked too. The branches filter
+  # matches the base, not the head, so restricting it leaves them unverified.
   pull_request:
-    branches: [source]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 何を

`lint.yml` と `codeql-analysis.yml` に 2 つの変更を入れます。コミットは分けてあります。

1. `pull_request` の `branches: [source]` を撤去
2. `concurrency` を追加(PR の古い実行だけ打ち切る。push は打ち切らない)

`actions/checkout` と `actions/setup-node` はこのリポジトリでは既に v7 なので、バージョンの変更はありません。

## なぜ

### 1. base フィルタ

`pull_request` の `branches` フィルタは **head ではなく base** を見ます。`[source]` に限定していると、中間ブランチ宛ての PR(stacked PR)にはどのワークフローもトリガされず、**チェックが 1 つも走らないままマージできます**。フィルタの見た目とは逆の効果です。

team-apm/apm でも同じ問題を team-apm/apm#2443 で直しました。public リポジトリなので標準ランナーに課金は無く、実行が増えるコストは実質ありません。

### 2. concurrency

base フィルタを外すと stacked PR の分だけ実行が増えるため、連続 push したときに同じ ref に対する古い実行が残ります。

push を対象外にしているのは、**source の各コミットについて Actions のステータスを残す必要がある**ためです。短時間に 2 つマージが来ると、先行コミットの実行が打ち切られてしまいます。

`release.yml` と `check-update.yml` には入れていません。どちらも PR では走らず、直列化すると公開の挙動が変わるためです。

## 確認したこと

- `yarn lint`(prettier + eslint)が緑
- ステージしたのは `.github/workflows/` の 2 ファイルのみ(作業ツリーに `.DS_Store` があるため確認済み)

## 関連

org 内の 4 リポジトリで同じ修正を出しています。apm は team-apm/apm#2443 でマージ済み、apm-schema は team-apm/apm-schema#351、apm-web は team-apm/apm-web#807 です。

データの検証まわり(スキーマ検証が動かなくなっている件、`modified` が毎リリース書き換わる件)は別 PR にします。