### PR TITLE
fix: スキーマ検証を動く状態に戻し、実際に走らせる

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,10 @@ jobs:
           cache: yarn
       - run: yarn install
       - run: yarn run lint
+      # v3/*.json is generated from the YAML sources and is not committed,
+      # so it has to be built before the schema check can see it. Without
+      # the main branch the modified timestamps it produces are meaningless,
+      # but only the shape of the data is being validated here.
+      - name: Generate the published JSON
+        run: yarn run release
+      - run: yarn run lint:jsonschema

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
           cache: yarn
       - run: yarn install
       - run: yarn run release
+      # The published JSON is generated rather than committed, so this is
+      # the only point at which it can be checked against apm-schema before
+      # apm downloads it. Failing here leaves the previous release on main
+      # in place instead of publishing data apm cannot read.
+      - run: yarn run lint:jsonschema
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "generate-releases": "tsx util/generate-releases.ts",
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint --fix-dry-run .",
-    "lint:jsonschema": "ajv -s node_modules/apm-schema/v3/schema/core.json -d v3/core.json && ajv -s node_modules/apm-schema/v3/schema/packages.json -d v3/packages.json && ajv -s node_modules/apm-schema/v3/schema/scripts.json -d v3/scripts.json && ajv -c ajv-formats -s node_modules/apm-schema/v3/schema/list.json  -d v3/list.json && ajv -s node_modules/apm-schema/v3/schema/convert.json  -d v3/convert.json",
+    "lint:jsonschema": "ajv -s node_modules/apm-schema/v3/schema/core.json -d v3/core.json && ajv -s node_modules/apm-schema/v3/schema/packages.json -d 'v3/packages/*.json' && ajv -s node_modules/apm-schema/v3/schema/scripts.json -d v3/scripts.json && ajv -c ajv-formats -s node_modules/apm-schema/v3/schema/list.json -d v3/list.json && ajv -s node_modules/apm-schema/v3/schema/convert.json -d v3/convert.json",
     "lint:prettier": "prettier --check .",
     "mod-convert": "tsx util/update-mod.ts --convert",
     "mod-core": "tsx util/update-mod.ts --core",


### PR DESCRIPTION
## 何を

1. `lint:jsonschema` が現在の出力形を見るように直す
2. 公開の直前(`release.yml`)で検証する
3. PR でも検証する(`lint.yml`)

## なぜ

### 1. `lint:jsonschema` は今、実行すると落ちます

`e5f8610` の YAML 化リファクタで `release.ts` の出力が単一の `v3/packages.json` から**開発者ごとの `v3/packages/<developer>.json`**(48 人分 × pretty/min = 96 ファイル)に変わりました。`lint:jsonschema` は古い `v3/packages.json` を見たままなので、2 番目のステップで死にます。

```
$ yarn run lint:jsonschema
v3/core.json valid
error:  Cannot find data file v3/packages.json
error Command failed with exit code 2.
```

`f6fda01`(Remove jsonschema linting from the lint script for simplification)が `lint` から外したのは、おそらくこれが理由です。**外した判断自体は正しく、スクリプトが壊れていたのが実態**でした。

glob に直すと通ります。min 側も含めて検証するので、minify で壊れた場合も捕まります。

```
$ yarn run lint:jsonschema
（100 ファイル valid — packages 96 + core + scripts + list + convert）
```

現在のデータはすべて妥当です。**このコミットでデータは 1 バイトも変わりません。**

### 2. 公開前に検証が無い

`release.yml` は YAML から `v3/*.json` を生成して、そのまま `main` へ deploy します。生成と公開の間に apm-schema との突き合わせが 1 つもありません。**apm が読めない形のデータがそのまま公開され、気付くのは利用者**という経路が開いています。

`release.ts` は `yaml.load(...) as Core` のように**型アサーション**でスキーマ型に当てているだけなので、これはコンパイル時の主張であって実行時の検証ではありません。型はこの穴を塞ぎません。

Deploy の**前**に置いているので、落ちた場合は `main` の既存リリースがそのまま残ります。

### 3. PR で検証が無い

`src/**/*.yaml` を編集する PR に走るのは prettier と eslint だけです。どちらも apm が期待する形を知りません。生成物は git に入っていないので、検証の前に組み立てる必要があります。

## 確認したこと

- `yarn run lint:jsonschema` がローカルで緑(100 ファイル valid)
- `yarn lint` / `npx prettier --check package.json` が緑
- `v3/` は `.gitignore` の `v[0-9]*/` に該当するため、生成物がコミットに混ざらないことを確認

## 確認してほしいこと

### 自動更新 PR には効きません

**この変更は #968 のような自動更新 PR には効きません。** `peter-evans/create-pull-request` が `GITHUB_TOKEN` で作った PR は、GitHub の再帰防止のため**ワークフローを一切トリガしません**。#968 がチェック 0 件なのはこれが理由です。

対処の候補は 2 つあります。どちらもメンテナ判断が要るので、この PR には入れていません。

| 案 | 効果 | コスト |
| --- | --- | --- |
| `create-pull-request` の `token` を PAT にする | 自動更新 PR にも `lint.yml` が普通に走る | PAT の発行とシークレット登録が必要 |
| `check-update.yml` の中で PR 作成前に検証する | PAT 不要 | 1 件でも不正だと**更新 PR ごと止まる** |

### 補足

`lint.yml` は team-apm/apm-data#996 でも触っているため、どちらかがマージされたら rebase が要ります。