### PR TITLE
fix(ci): リリースのたびに全件の modified が書き換わるのを止める

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
+      # release.ts decides whether each modified timestamp advances by
+      # comparing the generated file against the copy already published on
+      # main. checkout only fetches the ref being built, so without this
+      # every file looks new and every timestamp is rewritten on every run.
+      - run: git fetch --depth=1 origin main:main
       - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'


### PR DESCRIPTION
## 症状

`v3/list.json` の `modified` **50 件が、リリースのたびに全部その瞬間の時刻へ書き換わっています**。公開済みのデータを 3 版さかのぼると、いずれも 49〜50 件が同一ミリ秒帯に固まっています。

| リリース | エントリ数 | 相異なる `modified` | 最頻値 |
| --- | --- | --- | --- |
| 2026-08-19 | 50 | 49 | `2026-08-19T18:12:38.387Z` |
| 2026-08-19 | 50 | 49 | `2026-08-19T14:57:54.492Z` |
| 2025-10-31 | 50 | 49 | `2025-10-31T07:56:31.383Z` |

`v3/SPECIFICATION.md` は `DataFileInfo.modified` を「データファイルの更新日時」と定めており、apm-schema も `"description": "Update date and time of the file"` としています。**現状この欄は「最後にリリースワークフローが走った時刻」しか表していません。**

## 原因

`release.ts` の `isDifferentFromMain()` は、生成したファイルと **`main` に公開済みのファイル**を blob hash で突き合わせて「変わったか」を判定します。

ところが `actions/checkout` は既定でビルド対象の ref しか取得しないため、ワークスペースに `main` が存在しません。`git ls-tree -r main` が失敗 → `mainHash` が `null` → 関数は「ワークスペースにしかない新規ファイル」の枝に入り、**全件が「変更あり」**になります。

CI と同じ shallow clone で再現しました。

```
$ git clone --depth=1 --branch source ...
$ git ls-tree -r main -- v3/core.json
fatal: Not a valid object name main
```

## 影響

apm はこの欄を「取り直すかどうか」の判断に使っています(`src/main/services/core.ts`)。

- `max(packages[].modified)` が進む → `refreshPackagesList()` でパッケージ一覧を全部ダウンロードし直す
- `max(scripts[].modified)` が進む → スクリプト一覧を取り直す
- `core.modified` が進む → 本体の最新版チェックが走る
- `convert.modified` が進む → `convertPackageIds()` が走り、変換辞書を取り直して ledger のトランザクションを 1 回実行する

**今はデータが 1 バイトも変わっていなくても、リリースのたびに全利用者でこれが起きます。**

なお #1045(最終更新日で並び替えたい)のような機能も、この欄が意味を持たない限り成立しません。

## 修正

checkout の直後に `main` を depth 1 で取得するだけです。

```yaml
      - uses: actions/checkout@v7
      - run: git fetch --depth=1 origin main:main
```

## 検証

**1. ローカルで再現と修正の確認**

| 条件 | 1 回目 | 2 回目 | 公開中(`main`)の値 |
| --- | --- | --- | --- |
| `main` 無し(= 現在の CI) | `06:17:23.684Z` | `06:17:25.436Z` | — |
| `main` 有り | `2026-08-19T18:12:38.387Z` | 同じ | **一致** |

`main` さえあれば `isDifferentFromMain()` は設計どおり動き、内容が変わっていないファイルの値を保持します。

**2. shallow clone で修正案そのものを確認**

CI と同じ `--depth=1 --branch source` のクローンで:

```
$ git fetch --depth=1 origin main:main
 * [new branch]      main       -> main
$ git ls-tree -r main -- v3/core.json
100644 blob dfe46513...	v3/core.json
$ git show main:v3/list.json | head -5
{
  "core": {
    "path": "core.json",
    "modified": "2026-08-19T18:12:38.387Z"
```

`ls-tree` と `show` の両方が通ります。`.git` は取得後も 936K で、コストはほぼありません。

## 限界

**公開済みの誤った値は直りません。** 内容が変わっていないファイルは、最後に付与された(誤った)値を保持し続けます。この PR が止めるのは churn の継続だけです。既存の値を実際の更新日時に振り直したい場合は、git 履歴から各ファイルの最終変更時刻を再構成する別作業になります。必要でしたら別 issue にします。

## 補足

`release.yml` は team-apm/apm-data#997 でも触っていますが、変更箇所が別(あちらは Deploy の直前)なので競合しない想定です。