### PR TITLE
build(deps): dependabot の設定を apm と同じ水準に揃える

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,44 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'daily'
+      # Weekly rather than daily: a single maintainer cannot keep up with a
+      # daily stream, and unreviewed pull requests accumulate until Dependabot
+      # pauses its own updates for the repository.
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    ignore:
+      # Majors are taken deliberately, one major per pull request. Listed by
+      # name rather than as '*' because ignore conditions also suppress
+      # Dependabot security updates, and a blanket rule would hide a fix that
+      # only ships in a new major.
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript-eslint'
+        update-types: ['version-update:semver-major']
     groups:
       eslint:
         patterns:
           - '@eslint/*'
           - 'eslint*'
+      typescript-eslint:
+        patterns:
+          - 'typescript-eslint'
+      prettier:
+        patterns:
+          - 'prettier*'
+      types:
+        patterns:
+          - '@types/*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## 何を

`.github/dependabot.yml` を apm と同じ運用水準に揃えます。

| 項目 | 変更前 | 変更後 |
| --- | --- | --- |
| `interval` | `daily` | `weekly` |
| `open-pull-requests-limit` (npm) | 未設定(既定 5) | `5` を明示 |
| `open-pull-requests-limit` (actions) | 未設定(既定 5) | `2` |
| major の `ignore` | 無し | `eslint` / `typescript-eslint` |
| `groups` | eslint | eslint / typescript-eslint / prettier / `@types/*` |

## なぜ

### 頻度と上限

apm の `dependabot.yml` には理由がコメントで書かれています — **「1人運用で追い切れる頻度に抑える(daily だと PR が滞留する)」**。この判断が他のリポジトリへ持ち込まれておらず、ここは `daily` のままでした。

このリポジトリの dependabot はまだ動いていますが(最新 PR は 2026-08-19)、9 本が開いたままです。**同じ設定だった apm-web と apm-schema は、その先で GitHub に version updates を一時停止されました** — apm-web は 2026-04-14、apm-schema は 2026-04-10 を最後に PR が 1 本も来ていません。GitHub は「メンテナが dependabot PR に反応しなくなると version updates を一時停止する」と明記しています。

### `@types/*` のグループ化

単発 PR の細かい流れを 1 本に畳みます。`@types/node` は 10 月の 13 日間で 3 回上げられ、**3 本とも未マージで閉じられています**。

### major を除外する理由と、`'*'` にしない理由

メジャー更新は「1 PR = 1 major」で計画的に上げる方針(apm の AGENTS.md)に合わせ、dependabot からは外します。

ただし **`ignore` はパッケージ名で列挙し、`dependency-name: '*'` は使いません**。GitHub の[ドキュメント](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)によれば `ignore` は version updates だけでなく **security updates にも適用される**ため、`'*'` で major を一括除外すると「新しい major でしか出ない修正」まで隠れてしまいます。

## 影響しないもの

- **dependabot の security updates は別機能**なので、この変更で止まりません
- 既に開いている PR には影響しません(別途処理します)

## 関連

CI の統一は team-apm/apm-data#996、スキーマ検証は team-apm/apm-data#997、`modified` の churn は team-apm/apm-data#998 です。滞留 PR の処理と `ncu` による一括更新は別途。