### PR TITLE
fix: modified の書き換えが #998 で止まらなかった本当の原因を直す

### DIFF
--- a/util/release.ts
+++ b/util/release.ts
@@ -52,16 +52,16 @@ function core(): void {
     fs.readFileSync(EXEDIT_YAML_PATH, 'utf-8'),
   ) as Core['exedit'];
   const coreObj = { version: VERSION, aviutl, exedit } as Core;
-  void fs.outputJson(V3_CORE_JSON, coreObj, { spaces: 2 });
-  void fs.outputJson(V3_CORE_MIN_JSON, coreObj);
+  fs.outputJsonSync(V3_CORE_JSON, coreObj, { spaces: 2 });
+  fs.outputJsonSync(V3_CORE_MIN_JSON, coreObj);
 }
 
 function convert(): void {
   const convertObj = yaml.load(
     fs.readFileSync(CONVERT_YAML_PATH, 'utf-8'),
   ) as Convert;
-  void fs.outputJson(V3_CONVERT_JSON, convertObj, { spaces: 2 });
-  void fs.outputJson(V3_CONVERT_MIN_JSON, convertObj);
+  fs.outputJsonSync(V3_CONVERT_JSON, convertObj, { spaces: 2 });
+  fs.outputJsonSync(V3_CONVERT_MIN_JSON, convertObj);
 }
 
 // Walk through src/packages/* and read package.yaml files
@@ -96,10 +96,10 @@ function packages(): void {
   for (const [devDir, pkgs] of Object.entries(packagesList)) {
     // devDir is the src/packages/<devDir> directory name (ASCII)
     const packagesObj = { version: VERSION, packages: pkgs } as Packages;
-    void fs.outputJson(`${V3_PACKAGES_DIR}/${devDir}.json`, packagesObj, {
+    fs.outputJsonSync(`${V3_PACKAGES_DIR}/${devDir}.json`, packagesObj, {
       spaces: 2,
     });
-    void fs.outputJson(`${V3_PACKAGES_DIR}/${devDir}.min.json`, packagesObj);
+    fs.outputJsonSync(`${V3_PACKAGES_DIR}/${devDir}.min.json`, packagesObj);
   }
 }
 
@@ -111,8 +111,8 @@ function scripts(): void {
     fs.readFileSync(SCRIPTS_SCRIPTS_YAML_PATH, 'utf-8'),
   ) as Scripts['scripts'];
   const scriptsJson = { webpage, scripts: scriptsObj } as Scripts;
-  void fs.outputJson(V3_SCRIPTS_JSON, scriptsJson, { spaces: 2 });
-  void fs.outputJson(V3_SCRIPTS_MIN_JSON, scriptsJson);
+  fs.outputJsonSync(V3_SCRIPTS_JSON, scriptsJson, { spaces: 2 });
+  fs.outputJsonSync(V3_SCRIPTS_MIN_JSON, scriptsJson);
 }
 
 /**
@@ -244,8 +244,8 @@ function list(): void {
       },
     ],
   } as List;
-  void fs.outputJson(V3_LIST_JSON, list, { spaces: 2 });
-  void fs.outputJson(V3_LIST_MIN_JSON, list);
+  fs.outputJsonSync(V3_LIST_JSON, list, { spaces: 2 });
+  fs.outputJsonSync(V3_LIST_MIN_JSON, list);
 }
 
 function main(): void {


### PR DESCRIPTION
## 先に結論

**team-apm/apm-data#998 では止まりませんでした。** マージ後のリリース 5 本を確認すると、`modified` 50 件は依然として毎回リリース時刻に書き換わっています。

```
08-23 13:20   50 件 / 全件が 2026-08-23T13:20 台
08-23 13:19   50 件 / 全件が 2026-08-23T13:19 台
08-23 13:01   50 件 / 全件が 2026-08-23T13:01 台
```

**原因が 2 つあり、#998 はそのうち 1 つしか直していませんでした。** 私の前回の検証が不十分だったためです(下の「検証の誤り」を参照)。

## #998 自体は効いています

ワークフローのログで `main` の取得は成功しています。

```
##[group]Run git fetch --depth=1 origin main:main
 * [new branch]      main       -> main
```

つまり `getListJsonFromMain()` と `git ls-tree -r main` は動くようになりました。その下にもう 1 つ原因がありました。

## 本当の原因: 生成の書き込みが待たれていない

`util/release.ts` の書き込みは **10 箇所すべてが `void fs.outputJson(...)`** — Promise を投げっぱなしにしていて、誰も await しません。

```ts
function main(): void {
  core();      // void fs.outputJson(V3_CORE_JSON, ...) を発行するだけ
  convert();
  packages();
  scripts();
  list();      // ここで git hash-object v3/core.json を実行する
}
```

`main()` は同期的に呼ぶだけなので、**`list()` が `v3/core.json` をハッシュしようとする時点で、その書き込みがまだ完了していません。** probe を仕込んで直接確認しました。

```
[probe] list() 開始時点: v3/core.json exists = false
```

`isDifferentFromMain()` はこれを「main には在るのに作業ツリーに無い」と読み、**削除された = 変更あり**の枝に入ります。結果、全件が「変更あり」になります。

### 2 つの原因が同じ症状を出していた

| | `getListJsonFromMain()` | `isDifferentFromMain()` | 結果 |
| --- | --- | --- | --- |
| #998 の前 | `main` が無く null → 既定値で `new Date()` | 両方無い → `false` | **全件 now** |
| #998 の後 | 前回の値を取得できる ✅ | 書き込み未完了 → 「削除された」→ `true` | **全件 now** |

経路が違うだけで結果が同じだったため、1 つ目を直しても表からは何も変わりませんでした。

## 修正

`void fs.outputJson(` を `fs.outputJsonSync(` に置き換えます(10 箇所)。`main()` を同期のまま保てて、レースが消えます。生成するファイルは 100 個程度なので同期 I/O のコストは問題になりません。

## 公開データは壊れていません

Node はイベントループが空になるまでプロセスを終えないので、**ファイル自体は最終的に必ず正しく書かれます**。壊れていたのは 1 回の実行の中の順序だけです。

## 検証(まっさらな shallow clone、CI と同一条件)

`--depth=1 --branch source` でクローンし、`main` を取得し、`v3/` が `SPECIFICATION.md` だけの状態から 1 回だけ実行しました。

| | 修正前 | 修正後 | 公開中(`main`) |
| --- | --- | --- | --- |
| `core.modified` | `2026-08-23T20:14:43.955Z` | **`2026-08-23T13:20:49.752Z`** | `2026-08-23T13:20:49.752Z` |
| `convert.modified` | 実行時刻 | **`13:20:49.756Z`** | 一致 |
| `packages[]` 48 件 | 全件が実行時刻 | **全件が `13:20` 台** | 一致 |

生成物そのものも変わっていないことを確認しました。

- スキーマ検証: **100 / 100 valid**
- `core.json` / `convert.json` / `scripts.json`: 公開中と**バイト一致**
- `packages/*.json` **96 件すべて**が公開中とバイト一致

## 検証の誤り(前回)

team-apm/apm-data#998 で「1 回目と 2 回目が同じ値になった」と報告しましたが、**あの作業ツリーには前の実行で作った `v3/` が既に残っていました**。ファイルが存在する状態を測っていたので、実質 2 回目以降の挙動しか見ていませんでした。

**CI の実行は毎回が 1 回目です。** 今回はクローンからやり直して 1 回目を測っています。

## この後

マージ後の最初のリリースでは、`main` 上の内容と生成物が一致するファイルの `modified` が **`2026-08-23T13:20:49` 台のまま固定**されるはずです。それが確認できれば止まったと言えます。既に公開されてしまった値そのものは直りません(#998 に書いたとおりです)。