### PR TITLE
build(deps): @eslint/* の major も ignore に含める

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
       # only ships in a new major.
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+      # @eslint/js ships in lockstep with eslint, so ignoring only the latter
+      # lets a major land on one half of the pair while the other stays behind.
+      - dependency-name: '@eslint/*'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'typescript-eslint'
         update-types: ['version-update:semver-major']
     groups:


### PR DESCRIPTION
## 何を

`.github/dependabot.yml` の `ignore` に `@eslint/*` を追加します。

```diff
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+      # @eslint/js ships in lockstep with eslint, so ignoring only the latter
+      # lets a major land on one half of the pair while the other stays behind.
+      - dependency-name: '@eslint/*'
+        update-types: ['version-update:semver-major']
```

## なぜ

team-apm/apm-data#999 で `eslint` の major を除外しましたが、**`@eslint/js` を入れ忘れていました**。両者は同じバージョンで同時にリリースされます。

dependabot は数時間でこの穴を突いてきました。team-apm/apm-data#1004 がそれです。

```diff
-    "@eslint/js": "^9.39.5",
+    "@eslint/js": "^10.0.1",
```

`eslint` は `^9.39.5` のまま残るので、**同じリリースの片割れだけが major をまたぐ**状態になります。

`@eslint/*` に広げれば対になって動くので、eslint 9 → 10 は単独の PR として意図的に上げられます。

## この後

team-apm/apm-data#1004 は不要になります。dependabot は ignore 条件に該当するようになった PR を次回実行時に閉じますが、閉じなければ手で閉じてください。

同じ穴が apm-schema と apm-web にもあるので、それぞれ別 PR を出しています。apm 本体は `@eslint/js` を依存に持っていないため該当しません。