### PR TITLE
fix(packages): rigaya の死んだ Google Drive ミラーを削除する

### DIFF
--- a/src/packages/rigaya/afs/package.yaml
+++ b/src/packages/rigaya/afs/package.yaml
@@ -7,8 +7,6 @@ originalDeveloper: aji
 pageURL: https://rigaya34589.blog.fc2.com/blog-category-14.html
 downloadURLs:
   - https://1drv.ms/f/s!AsYziax1Q91rhBs2o7PMtyiEP8gC
-  - >-
-    https://drive.google.com/folderview?id=0BzA4dIFteM2dSXduMXdPMXBjeFk&usp=sharing
 latestVersion: 7.5a+22
 files:
   - filename: afsvf.auf

--- a/src/packages/rigaya/bandingMTSIMD/package.yaml
+++ b/src/packages/rigaya/bandingMTSIMD/package.yaml
@@ -6,8 +6,6 @@ developer: rigaya
 originalDeveloper: flash3kyuu
 pageURL: https://rigaya34589.blog.fc2.com/blog-category-15.html
 downloadURLs:
-  - >-
-    https://drive.google.com/folderview?id=0BzA4dIFteM2dQ1U3dG1mQ3Z5QWM&usp=sharing
   - https://1drv.ms/f/s!AsYziax1Q91rhEGimA7oABVfdmkE
 latestVersion: v17+8
 files:

--- a/src/packages/rigaya/delogoSIMD/package.yaml
+++ b/src/packages/rigaya/delogoSIMD/package.yaml
@@ -7,8 +7,6 @@ originalDeveloper: MakKi
 pageURL: https://rigaya34589.blog.fc2.com/blog-category-20.html
 downloadURLs:
   - https://1drv.ms/f/s!AsYziax1Q91rlQoaLBz34MoNMe69
-  - >-
-    https://drive.google.com/folderview?id=0BzA4dIFteM2dZEhId3NQaWZGbXc&usp=sharing
 latestVersion: r17
 files:
   - filename: plugins/delogo.auf

--- a/src/packages/rigaya/edgelevelMT/package.yaml
+++ b/src/packages/rigaya/edgelevelMT/package.yaml
@@ -8,8 +8,6 @@ originalDeveloper: flash3kyuu
 pageURL: https://rigaya34589.blog.fc2.com/blog-category-11.html
 downloadURLs:
   - https://1drv.ms/u/s!AsYziax1Q91rgjecLz36N1c41syz?e=7BeQTq
-  - >-
-    https://drive.google.com/drive/folders/0BzA4dIFteM2dSEZZbmdOWDNuSHM?usp=sharing
 latestVersion: v9
 files:
   - filename: plugins/edgelevelMT.auf


### PR DESCRIPTION
## 何を

rigaya の 4 パッケージから、404 を返す Google Drive のフォルダリンクを削除します。

| ID | 削除前 | 削除後 |
| --- | --- | --- |
| `rigaya/afs` | 1drv(200) → drive(**404**) | 1drv のみ |
| `rigaya/bandingMTSIMD` | **drive(404)** → 1drv(200) | 1drv のみ |
| `rigaya/delogoSIMD` | 1drv(200) → drive(**404**) | 1drv のみ |
| `rigaya/edgelevelMT` | 1drv(200) → drive(**404**) | 1drv のみ |

## なぜ

### `bandingMTSIMD` は実際にインストールできません

apm は **`downloadURLs[0]` しか使わず、2 番目以降にフォールバックしません**([`packageInstall.ts`](https://github.com/team-apm/apm/blob/main/src/main/services/packageInstall.ts))。

```ts
packageState.info.downloadURLs[0],
```

`bandingMTSIMD` は死んだ Google Drive リンクが**先頭**にあったため、生きている OneDrive ミラーが登録されているにもかかわらずインストールできない状態でした。削除すると OneDrive が先頭に繰り上がり、**インストールできるようになります**。

残り 3 件は死んだリンクが 2 番目にあり、apm はそこを読まないので実害はありませんでした。ただし「配布場所を指していないエントリ」であることに変わりはないので、同じ理由で削除します。

### どうやって見つけたか

公開中の `v3` データから全 URL を抽出し、実際に叩いて確認しました。

- 対象: 285 パッケージ / downloadURL 382 件 + pageURL 285 件 = **667 URL**
- 条件: ブラウザの User-Agent、リダイレクト追従、タイムアウト 25 秒

結果、**`downloadURLs[0]` が失敗するパッケージが 30 件(10.5%)** ありました。内訳は `hazumurhythm.com` が 23 件、`scrapbox.io/ePi5131` が 6 件、そしてこの `bandingMTSIMD` です。

**この PR で直せるのは `bandingMTSIMD` の 1 件だけ**です。残り 29 件は配布元そのものが消えており、作者が今どこで配布しているかを確定する必要があるため、別途扱います。

## 確認したこと

- `yarn lint`(prettier + eslint)が緑
- 生成後のスキーマ検証が **100 / 100 valid**
- 生成された `v3/packages/rigaya.json` で 4 件とも `downloadURLs` が 1 件になり、いずれも生きている OneDrive の URL であることを確認