### PR TITLE
feat: 配布 URL が死んだことを検知する

### DIFF
--- a/.github/workflows/link-health.yml
+++ b/.github/workflows/link-health.yml
@@ -1,0 +1,75 @@
+name: Link Health
+
+on:
+  schedule:
+    # 週次。check-update(毎日 20:43 UTC)と時間帯をずらして、同じ配布ホストへ
+    # 同時に当たらないようにしている
+    - cron: '17 18 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check distribution links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+
+      # 進捗は stderr、レポートは stdout に出る
+      - name: Probe distribution URLs
+        # --silent が無いと yarn のバナーがレポートの先頭に混ざる
+        run: yarn --silent run check-links > "$RUNNER_TEMP/report.md"
+
+      # 追跡用の issue は 1 本だけ持ち、毎週その本文を差し替える。
+      # 週ごとに新しい issue を立てると、直っていない同じ 30 件が積み上がる。
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          body_file="$RUNNER_TEMP/body.md"
+          {
+            cat "$RUNNER_TEMP/report.md"
+            echo
+            echo '---'
+            echo
+            echo "この issue は [Link Health]($RUN_URL) が毎週書き換えています。手で編集しても次回の実行で上書きされます。"
+            echo
+            echo '配布元が消えたパッケージを直すには「作者が今どこで配布しているか」を確定する必要があり、それは人間の判断です。このワークフローは検知だけを担当します。'
+          } > "$body_file"
+
+          # ラベルがまだ無い初回は gh がエラーを返すので、空として扱う
+          existing=$(gh issue list --repo "$REPO" --state open --label link-health \
+            --json number --jq '.[0].number // empty' 2>/dev/null || true)
+
+          if grep -q '^すべての配布 URL に到達できました。$' "$RUNNER_TEMP/report.md"; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$REPO" \
+                --body "すべての配布 URL に到達できました。閉じます。"
+              gh issue close "$existing" --repo "$REPO"
+            fi
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$REPO" --body-file "$body_file"
+          else
+            gh label create link-health --repo "$REPO" \
+              --description '配布 URL の到達性(自動検知)' --color 'B60205' 2>/dev/null || true
+            gh issue create --repo "$REPO" --label link-health \
+              --title '配布 URL に到達できないパッケージがある' --body-file "$body_file"
+          fi

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "ato lash <28973861+hal-shu-sato@users.noreply.github.com>",
   "scripts": {
     "check-convert": "tsx util/check-convert.ts",
+    "check-links": "tsx util/check-links.ts",
     "check-update": "tsx util/check-update.ts",
     "fix": "run-s fix:prettier fix:eslint",
     "fix:eslint": "eslint --fix .",

--- a/util/check-links.ts
+++ b/util/check-links.ts
@@ -1,0 +1,298 @@
+// > yarn run check-links
+//
+// src/ 以下の YAML に書かれた配布 URL を実際に叩き、到達できなかったものを
+// Markdown で報告する。データは書き換えない。
+//
+// 何のためか: check-update.ts が見ているのは「既知パッケージの新しいバージョン」
+// だけで、配布元そのものが消えたことは誰も見ていない。実際、2 年かけて 1 割の
+// パッケージが静かに導入不能になっていた。これはその腐敗を検知するためだけの
+// スクリプトで、直すのは人間の仕事(配布元の移転先を確定する判断が要るため)。
+
+import chalk from 'chalk';
+import { existsSync, readdirSync, readFileSync } from 'fs-extra';
+import yaml from 'js-yaml';
+
+const { red, yellow, green, gray } = chalk;
+
+const SRC_DIR = 'src/';
+const CONCURRENCY = 8;
+const TIMEOUT_MS = 25_000;
+// 証明書チェーンが不完全なサイトで Node の fetch だけが失敗する理由。
+// apm は Electron(Chromium)で動き、足りない中間証明書を自分で取りに行くため、
+// これに当たるものは利用者からは到達できる。配布終了と混ぜてはいけない。
+const TLS_CHAIN_ERRORS = [
+  'unable to get local issuer certificate',
+  'unable to verify the first certificate',
+  'self-signed certificate',
+  'self signed certificate',
+];
+
+// 一時的な不調と恒久的な消滅を区別するための待ち時間
+const RETRY_DELAYS_MS = [3_000, 15_000];
+
+// apm 本体は Electron のセッションでダウンロードするため、ブラウザとして扱われる。
+// User-Agent を揃えないと、bot を弾くだけのホストを「配布終了」と誤検知する
+// (実測で OneDrive が 403 になった)。利用者が実際に受け取る結果に合わせる。
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+type Target = {
+  /** パッケージ ID、または本体・スクリプト一覧を指す擬似 ID */
+  owner: string;
+  /** downloadURLs の何番目か。pageURL などは undefined */
+  index?: number;
+  kind: 'download' | 'page';
+  url: string;
+};
+
+type Result = Target & { status: number; error?: string; tls?: boolean };
+
+/**
+ * Collects every probeable distribution URL from the YAML sources.
+ * @returns {Target[]} The URLs to probe.
+ */
+function collectTargets(): Target[] {
+  const targets: Target[] = [];
+
+  const packagesDir = `${SRC_DIR}packages/`;
+  for (const developer of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!developer.isDirectory()) continue;
+    const developerPath = `${packagesDir}${developer.name}`;
+    for (const pkg of readdirSync(developerPath, { withFileTypes: true })) {
+      if (!pkg.isDirectory()) continue;
+      const yamlPath = `${developerPath}/${pkg.name}/package.yaml`;
+      if (!existsSync(yamlPath)) continue;
+      const obj = yaml.load(readFileSync(yamlPath, 'utf-8')) as {
+        id?: string;
+        pageURL?: string;
+        downloadURLs?: string[];
+      };
+      const owner = obj.id ?? `${developer.name}/${pkg.name}`;
+      obj.downloadURLs?.forEach((url, index) => {
+        if (isProbeable(url))
+          targets.push({ owner, index, kind: 'download', url });
+      });
+      if (obj.pageURL && isProbeable(obj.pageURL))
+        targets.push({ owner, kind: 'page', url: obj.pageURL });
+    }
+  }
+
+  const webpagePath = `${SRC_DIR}scripts/webpage.yaml`;
+  if (existsSync(webpagePath)) {
+    const pages = yaml.load(readFileSync(webpagePath, 'utf-8')) as {
+      url?: string;
+      developer?: string;
+    }[];
+    for (const page of pages)
+      if (page.url && isProbeable(page.url))
+        targets.push({
+          owner: `scripts:${page.developer ?? '?'}`,
+          kind: 'page',
+          url: page.url,
+        });
+  }
+
+  for (const core of ['aviutl', 'exedit']) {
+    const corePath = `${SRC_DIR}core/${core}.yaml`;
+    if (!existsSync(corePath)) continue;
+    const obj = yaml.load(readFileSync(corePath, 'utf-8')) as {
+      releases?: { url?: string }[];
+    };
+    obj.releases?.forEach((release, index) => {
+      if (release.url && isProbeable(release.url))
+        targets.push({
+          owner: `core:${core}`,
+          index,
+          kind: 'download',
+          url: release.url,
+        });
+    });
+  }
+
+  return targets;
+}
+
+/**
+ * Returns whether a URL can be requested as-is.
+ * @param {string} url - The URL to test.
+ * @returns {boolean} False for glob patterns and non-http schemes.
+ */
+function isProbeable(url: string): boolean {
+  return /^https?:\/\//.test(url) && !url.includes('*');
+}
+
+/**
+ * Requests a URL once and reports the resulting status.
+ * @param {string} url - The URL to request.
+ * @returns {Promise<{ status: number; error?: string }>} 0 on a network failure.
+ */
+async function requestOnce(
+  url: string,
+): Promise<{ status: number; error?: string }> {
+  try {
+    const response = await fetch(url, {
+      redirect: 'follow',
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    // 本文は不要。読まずに捨てないと接続が開いたままになる
+    await response.body?.cancel();
+    return { status: response.status };
+  } catch (e) {
+    // fetch の失敗理由は cause 側にしか入らない
+    const cause =
+      e instanceof Error ? (e.cause as Error | undefined) : undefined;
+    const message =
+      cause?.message ?? (e instanceof Error ? e.message : String(e));
+    return {
+      status: 0,
+      error: message,
+      tls: TLS_CHAIN_ERRORS.some((t) => message.includes(t)),
+    };
+  }
+}
+
+/**
+ * Probes a URL, retrying with a delay so a hiccup is not reported as rot.
+ * @param {Target} target - The URL to probe.
+ * @returns {Promise<Result>} The probe result.
+ */
+async function probe(target: Target): Promise<Result> {
+  let last = await requestOnce(target.url);
+  // ネットワーク断と 5xx は相手側の一時的な不調でも起きる。週次で issue を
+  // 立てる以上、1 回の揺らぎを「配布終了」と報告してはいけない。
+  //
+  // 間を空けずに試し直しても意味が無い: 実測で purinka.work が一度だけ
+  // fetch failed になり、連続した再試行も同じく失敗したが、数秒後には 200 に
+  // 戻っていた。相手が立ち直る時間を与えるため、待ってから試し直す。
+  for (const waitMs of RETRY_DELAYS_MS) {
+    if (last.tls) break; // 証明書の問題は待っても変わらない
+    if (last.status !== 0 && last.status < 500) break;
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+    last = await requestOnce(target.url);
+  }
+  return { ...target, ...last };
+}
+
+/**
+ * Runs an async mapper over items with a fixed concurrency.
+ * @param {T[]} items - The items to process.
+ * @param {number} limit - Maximum number of in-flight operations.
+ * @param {(item: T) => Promise<R>} fn - The mapper.
+ * @returns {Promise<R[]>} The results, in input order.
+ */
+async function pool<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      for (;;) {
+        const i = next++;
+        if (i >= items.length) return;
+        results[i] = await fn(items[i]);
+      }
+    }),
+  );
+  return results;
+}
+
+/**
+ * Renders the Markdown report to stdout.
+ * @param {Result[]} results - Every probe result.
+ */
+function report(results: Result[]): void {
+  const reachable = (r: Result) => r.status >= 200 && r.status < 400;
+  // 証明書チェーンの問題は「配布が消えた」ではないので、失敗として数えない
+  const tlsOnly = results.filter((r) => !reachable(r) && r.tls);
+  const failed = results.filter((r) => !reachable(r) && !r.tls);
+
+  // apm は downloadURLs[0] しか使わず、2 番目以降にフォールバックしない
+  // (apm の src/main/services/packageInstall.ts)。先頭が死んでいるものだけが
+  // 「導入できない」で、それ以外は掃除の対象。
+  const blocking = failed.filter((r) => r.kind === 'download' && r.index === 0);
+  const unusedMirror = failed.filter(
+    (r) => r.kind === 'download' && r.index !== 0,
+  );
+  const pages = failed.filter((r) => r.kind === 'page');
+
+  const out: string[] = [];
+  out.push(
+    `検査した URL: ${results.length} 件 / 到達できなかったもの: ${failed.length} 件`,
+  );
+  out.push('');
+  if (failed.length === 0 && tlsOnly.length === 0) {
+    out.push('すべての配布 URL に到達できました。');
+    console.log(out.join('\n'));
+    return;
+  }
+
+  const table = (rows: Result[]) => {
+    out.push('| 対象 | HTTP | URL |');
+    out.push('| --- | --- | --- |');
+    for (const r of rows)
+      out.push(
+        `| \`${r.owner}\` | ${r.status === 0 ? `接続失敗(${r.error ?? ''})` : r.status} | ${r.url} |`,
+      );
+    out.push('');
+  };
+
+  if (blocking.length) {
+    out.push(`## 導入できない — ${blocking.length} 件`);
+    out.push('');
+    out.push(
+      'apm は `downloadURLs[0]` しか使わず、2 番目以降にフォールバックしません。' +
+        'ここに並んでいるものは利用者がインストールできない状態です。',
+    );
+    out.push('');
+    table(blocking);
+  }
+  if (unusedMirror.length) {
+    out.push(`## 使われていないミラーが死んでいる — ${unusedMirror.length} 件`);
+    out.push('');
+    out.push(
+      'apm は読まない位置なので実害はありませんが、配布場所を指していないエントリです。',
+    );
+    out.push('');
+    table(unusedMirror);
+  }
+  if (pages.length) {
+    out.push(`## 配布ページに飛べない — ${pages.length} 件`);
+    out.push('');
+    table(pages);
+  }
+  if (tlsOnly.length) {
+    out.push(`## 参考: 証明書チェーンが不完全 — ${tlsOnly.length} 件`);
+    out.push('');
+    out.push(
+      'このスクリプトの Node からは検証できませんでしたが、apm は Electron(Chromium)で ' +
+        '動き、足りない中間証明書を自分で取りに行くため、利用者からは到達できるはずです。' +
+        '配布が消えたわけではありません。',
+    );
+    out.push('');
+    table(tlsOnly);
+  }
+  console.log(out.join('\n'));
+}
+
+/**
+ * Entry point.
+ */
+async function main(): Promise<void> {
+  const targets = collectTargets();
+  console.error(gray(`${targets.length} 件の URL を検査します...`));
+  const results = await pool(targets, CONCURRENCY, async (t) => {
+    const r = await probe(t);
+    const ok = r.status >= 200 && r.status < 400;
+    console.error(
+      `${ok ? green('ok  ') : r.status === 0 ? red('err ') : yellow(String(r.status))} ${r.owner} ${gray(r.url)}`,
+    );
+    return r;
+  });
+  report(results);
+}
+
+void main();


### PR DESCRIPTION
## 何を

`util/check-links.ts` と週次ワークフローを追加します。`src/` 以下の YAML に書かれた配布 URL(684 件)を実際に叩き、到達できなかったものを **1 本の追跡 issue に集約**します。

**データは書き換えません。検知だけです。**

## なぜ

`check-update.ts` が見ているのは「既知パッケージに新しいバージョンが出たか」だけで、**配布元そのものが消えたことは誰も見ていません**。

理論上の話ではありません。公開中のデータを実測したところ、**285 件中 30 件(10.5%)がインストールできない状態**でした。

| 原因 | 件数 |
| --- | --- |
| `hazumurhythm.com` の配布パスが 404 | 23 |
| `scrapbox.io/ePi5131` が 401(非公開化) | 6 |
| `rigaya/bandingMTSIMD` の先頭 URL が 404 | 1(team-apm/apm-data#1013 で修正) |

どれも長期間壊れていましたが、**どこにも兆候が出ていませんでした**。

修理には「作者が今どこで配布しているか」を確定する必要があり、スクリプトが推測してよい種類の判断ではありません。**このワークフローは検知で止まり、あとは人間に渡します。**

## 誤検知を出さないための 3 つの区別

週次で issue を立てる以上、偽陽性が混じるとレポート全体の信用が落ちます。実装中に 3 種類とも実際に踏みました。

### 1. `downloadURLs[0]` だけを「導入できない」とする

apm は先頭の URL しか使わず、2 番目以降にフォールバックしません([apm の `packageInstall.ts`](https://github.com/team-apm/apm/blob/main/src/main/services/packageInstall.ts))。後ろのミラーが死んでいるのは「掃除の対象」であって「壊れている」ではないので、節を分けています。

### 2. 失敗は 3 秒後・15 秒後に試し直す

開発中に `purinka.work` が一度だけ `fetch failed` になりました。**間を空けない再試行では同じく失敗**し、数秒後には 200 に戻っていました。待たずに再試行するリトライは、この種の揺らぎに対して無力です。

### 3. 証明書チェーンの問題は別枠にする

同じ `purinka.work` は、`curl` では 200 なのに Node の `fetch` では失敗し続けました。理由は `unable to get local issuer certificate` — **中間証明書を送ってこないサイト**です。

Node は自前の CA リストしか見ないので落ちますが、**apm は Electron(Chromium)なので足りない証明書を自分で取りに行き、利用者は問題なく到達できます**。これを「配布終了」に混ぜると、生きているサイトを毎週告発し続けることになります。

同じ理由で User-Agent もブラウザのものにしています。既定の agent では OneDrive が 403 を返しました。**利用者が実際に受け取る結果に合わせる**のが目的です。

## issue の扱い

追跡用の issue は **1 本だけ持ち、毎週その本文を差し替えます**。週ごとに新しい issue を立てると、直っていない同じ 30 件が積み上がるためです。すべて到達できるようになったら自動で閉じます。

## 実行結果(ローカル)

```
検査した URL: 684 件 / 到達できなかったもの: 43 件

## 導入できない — 30 件
## 使われていないミラーが死んでいる — 3 件
## 配布ページに飛べない — 10 件
## 参考: 証明書チェーンが不完全 — 1 件
```

## 確認したこと

- `yarn lint`(prettier + eslint)が緑
- `yarn --silent run check-links` の標準出力が Markdown だけになること(`--silent` が無いと yarn のバナーがレポート先頭に混ざります)
- 進捗ログは stderr に出るのでレポートを汚さないこと