### PR TITLE
feat(ci): 自動更新 PR を GitHub App 名義で作れるようにする

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -13,6 +13,21 @@ jobs:
       TZ: 'Asia/Tokyo'
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      # A GitHub App token, unlike GITHUB_TOKEN, does trigger workflows, so the
+      # update pull request gets lint.yml and CodeQL the normal way. A personal
+      # access token would work too, but the pull request would then be authored
+      # by the person who issued it; the App keeps it attributable to a bot.
+      #
+      # Set up: install an App on this repository with contents:write and
+      # pull-requests:write, then add the APM_BOT_APP_ID variable and the
+      # APM_BOT_PRIVATE_KEY secret. Until the variable exists this step is
+      # skipped and the job behaves exactly as it does today.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        if: ${{ vars.APM_BOT_APP_ID != '' }}
+        with:
+          app-id: ${{ vars.APM_BOT_APP_ID }}
+          private-key: ${{ secrets.APM_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
@@ -41,10 +56,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          # Add a CREATE_PR_TOKEN secret holding a personal access token to have
-          # the pull request trigger workflows the normal way; the fallback keeps
-          # today's behaviour when it is absent.
-          token: ${{ secrets.CREATE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           commit-message: Update packages data
           branch: create-pull-request/check-update
           delete-branch: true


### PR DESCRIPTION
## 何を

`check-update.yml` の PR 作成トークンを、PAT ではなく **GitHub App のトークン**にできるようにします。

```yaml
      - uses: actions/create-github-app-token@v3
        id: app-token
        if: ${{ vars.APM_BOT_APP_ID != '' }}
        ...
          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
```

## なぜ PAT ではないのか

team-apm/apm-data#1001 で `CREATE_PR_TOKEN` のフックを置きましたが、**PAT を使うと PR の author が「そのトークンを発行した人」になります**。これは機械生成のデータ更新なので、書いていないメンテナ個人の名義になるのは適切ではありません。

GitHub App のトークンなら:

- PAT と同じく**ワークフローをトリガーします**(`lint.yml` と CodeQL が普通に走る)
- author は **bot** になります
- 権限が **App をインストールしたリポジトリだけ**にスコープされます(PAT は発行者が触れる全部)

## GITHUB_TOKEN を続ける道が細っている

GitHub は 2026 年 6 月中旬から、**`GITHUB_TOKEN` で作られた PR のワークフロー実行に手動承認を要求する**ようになりました。同一リポジトリのブランチからの PR でもです。どのみち移行が要ります。

## マージしても今は何も変わりません

`vars.APM_BOT_APP_ID` が未設定の間はこのステップが **skip** され、トークン式は `GITHUB_TOKEN` にフォールバックします。**現在の挙動と完全に同じ**です。

App ID を secret ではなく **variable** にしているのは、**secret はステップレベルの `if` 条件で参照できない**ためです(App ID は秘密ではないので問題ありません)。

## あなたにお願いすること(このPRのマージ後、好きなタイミングで)

1. org に GitHub App を 1 つ作る
2. このリポジトリにインストールし、権限は **Contents: write** と **Pull requests: write**
3. リポジトリ変数 `APM_BOT_APP_ID` に App ID を入れる
4. リポジトリシークレット `APM_BOT_PRIVATE_KEY` に秘密鍵を入れる

**秘密鍵を私に見せる必要はありません。** 4 つ揃った瞬間から、自動更新 PR に CI が付いて bot 名義になります。