### PR TITLE
fix(ci): 版に固定した downloadURL で最新リリースを追わない

### DIFF
--- a/src/packages/hebiiro/python32/package.yaml
+++ b/src/packages/hebiiro/python32/package.yaml
@@ -6,7 +6,7 @@ name: python実行環境
 pageURL: https://github.com/hebiiro/anti.aviutl.ultimate.plugin#readme
 overview: アルティメットプラグインの実行に必要なPython実行環境
 description: 蛇色(へびいろ)氏のプラグインの実行に必要な環境です。'python32_r36.zip'をダウンロードしてください。
-latestVersion: r117
+latestVersion: r36
 files:
   - filename: plugins/ultimate
     archivePath: plugins

--- a/util/check-update.ts
+++ b/util/check-update.ts
@@ -47,7 +47,12 @@ async function checkPackageUpdate(packageItem: Packages['packages'][number]) {
   if (
     exclude.includes(id) ||
     downloadURL.hostname !== 'github.com' ||
-    dirs[2] !== 'releases'
+    dirs[2] !== 'releases' ||
+    // /releases/tag/<tag> は特定の版に固定した URL。ここで最新リリースを見に
+    // 行くと、downloadURLs と description が古い版を指したまま latestVersion
+    // だけが進む。hebiiro/python32 が r36 のまま r117 になった経路がこれで、
+    // 同じリポジトリを共有する hebiiro/UltimatePlugin の版を拾っていた
+    dirs[3] === 'tag'
   )
     return result;
 


### PR DESCRIPTION
[#1011](https://github.com/team-apm/apm-data/pull/1011) が `hebiiro/python32` に持ち込んだ誤りと、その原因を直します。

## 何が起きたか

#1011 で python32 の `latestVersion` が **`r36` → `r117`** に上がりました。ところがこのパッケージは:

```yaml
downloadURLs:
  - https://github.com/hebiiro/anti.aviutl.ultimate.plugin/releases/tag/r36   # ← r36 に固定
description: … 'python32_r36.zip'をダウンロードしてください。                    # ← r36 と明記
latestVersion: r117                                                            # ← ここだけ進んだ
```

**URL も説明も r36 のまま、バージョン表記だけが r117 になりました。** しかも r117 は同じリポジトリ（`anti.aviutl.ultimate.plugin`）を共有する `hebiiro/UltimatePlugin` の版で、python32 のものではありません。

`releases` が空なので誤検知は出ませんが、apm は **r36 の中身を r117 として `apm.json` に記録します**。将来 r117 が本当に python32 として来たとき、導入済みと誤判定します。

## 原因

`util/check-update.ts` の門がパスの 3 番目までしか見ていません。

```ts
dirs[2] !== 'releases'   // /releases/tag/r36 も通ってしまう
```

`/releases/latest` かどうかを判定していないので、**版に固定した URL でもリポジトリの最新リリースを引いて `latestVersion` だけ進めます**。

## この PR でやること

門に `dirs[3] === 'tag'` を足し、python32 を `r36` へ戻します。

## 影響範囲は 1 件だけです

公開データ 285 件の `downloadURLs[0]` を数えました。

| 形 | 件数 | この PR 後 |
| --- | --- | --- |
| `/releases/latest` | 74 | 追う（変化なし） |
| `/releases`（裸） | 3 | 追う（変化なし） |
| `/releases/tag/<tag>` | **1**（python32） | **追わない**（変更） |
| `releases` 以外の github | 1 | 追わない（変化なし） |
| github 以外 | 206 | 追わない（変化なし） |

## 検証

門の判定を 5 種の URL で確かめました。

```
OK  追う     https://github.com/rigaya/NVEnc/releases/latest
OK  追う     https://github.com/oov/CacheText/releases
OK  追わない  https://github.com/hebiiro/anti.aviutl.ultimate.plugin/releases/tag/r36
OK  追わない  https://scrapbox.io/ePi5131/ease
OK  追わない  https://github.com/AiosCiao/VSThost4aviutl
```

`yarn lint:prettier` / `eslint` / `yarn release` / `yarn lint:jsonschema` すべて緑。生成物で `python32 = r36`、`UltimatePlugin = r117`（据え置き）を確認済みです。